### PR TITLE
feat: add array support for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,64 @@ The appropriate rule is chosen by finding the 'root' of the locale used: for exa
 
 If the provided functions are not enough (i.e. invented languages) it's possible to specify a custom pluralization function in the second parameter of setLocale. This function must return 'one', 'few', 'other', etc given a number.
 
+Arrays
+======
+
+Translation values can be arrays containing strings, interpolated values, and plural forms:
+
+```lua
+i18n.load({
+  en = {
+    -- Simple array of strings
+    greetings = {"Hello!", "Hi there!", "Howdy!"},
+
+    -- Arrays with interpolation
+    welcome = {
+      "Welcome to %{game_name}!",
+      "Player: %{player_name}",
+      "Level: %{level}"
+    },
+
+    -- Arrays with plural forms
+    status = {
+      "Game Status:",
+      {
+        one = "%{count} player online",
+        other = "%{count} players online"
+      },
+      {
+        one = "%{lives} life remaining",
+        other = "%{lives} lives remaining"
+      }
+    }
+  }
+})
+
+-- Usage
+i18n.setLocale('en')
+i18n('greetings')  -- Returns: {"Hello!", "Hi there!", "Howdy!"}
+
+i18n('welcome', {
+  game_name = "Adventure Time",
+  player_name = "Jake",
+  level = 5
+}) -- Returns interpolated array
+
+i18n('status', {
+  count = 3,
+  lives = 1
+}) -- Returns array with pluralized elements
+```
+
+Arrays maintain their order and can mix plain strings, interpolated values, and plural forms in any combination.
+This is particularly useful for:
+
+- Random message selection
+- Dialogue sequences
+- Multi-line status displays
+- Ordered game tutorials
+
+
 Fallbacks
 =========
 

--- a/i18n/init.lua
+++ b/i18n/init.lua
@@ -105,7 +105,7 @@ local function recursiveLoad(currentContext, data)
     composedKey = (currentContext and (currentContext .. '.') or "") .. tostring(k)
     assertPresent('load', composedKey, k)
     assertPresentOrTable('load', composedKey, v)
-    if type(v) == 'string' then
+    if type(v) == 'string' or isArray(v) then
       i18n.set(composedKey, v)
     else
       recursiveLoad(composedKey, v)

--- a/i18n/init.lua
+++ b/i18n/init.lua
@@ -88,7 +88,9 @@ end
 
 local function treatNode(node, data)
   if isArray(node) then
-    for k,v in ipairs(node) do
+    local iter = {ipairs(node)}
+    node = {}
+    for k,v in unpack(iter) do
       node[k] = treatNode(v, data)
     end
   elseif type(node) == 'string' then

--- a/i18n/interpolate.lua
+++ b/i18n/interpolate.lua
@@ -1,10 +1,28 @@
 local unpack = unpack or table.unpack -- lua 5.2 compat
 
+local interpolate = {}
+
 local FORMAT_CHARS = { c=1, d=1, E=1, e=1, f=1, g=1, G=1, i=1, o=1, u=1, X=1, x=1, s=1, q=1, ['%']=1 }
+
+local fieldPattern = "(.?)%%{%s*(.-)%s*}"
+local valuePattern = "(.?)%%<%s*(.-)%s*>%.([cdEefgGiouXxsq])"
+function interpolate.getInterpolationKey(string, variables)
+  for previous, key in string:gmatch(fieldPattern) do
+    if previous ~= "%" and variables[key] then
+      return key
+    end
+  end
+
+  for previous, key in string:gmatch(valuePattern) do
+    if previous ~= "%" and variables[key] then
+      return key
+    end
+  end
+end
 
 -- matches a string of type %{age}
 local function interpolateValue(string, variables)
-  return string:gsub("(.?)%%{%s*(.-)%s*}",
+  return string:gsub(fieldPattern,
     function (previous, key)
       if previous == "%" then
         return
@@ -16,7 +34,7 @@ end
 
 -- matches a string of type %<age>.d
 local function interpolateField(string, variables)
-  return string:gsub("(.?)%%<%s*(.-)%s*>%.([cdEefgGiouXxsq])",
+  return string:gsub(valuePattern,
     function (previous, key, format)
       if previous == "%" then
         return
@@ -46,7 +64,7 @@ local function unescapePercentages(string)
   end)
 end
 
-local function interpolate(pattern, variables)
+local function interpolateString(pattern, variables)
   variables = variables or {}
   local result = pattern
   result = interpolateValue(result, variables)
@@ -56,5 +74,7 @@ local function interpolate(pattern, variables)
   result = unescapePercentages(result)
   return result
 end
+
+setmetatable(interpolate, {__call = function(_, ...) return interpolateString(...) end})
 
 return interpolate

--- a/spec/en.lua
+++ b/spec/en.lua
@@ -1,6 +1,7 @@
 return {
   en = {
     hello = 'Hello!',
-    balance = 'Your account balance is %{value}.'
+    balance = 'Your account balance is %{value}.',
+    array = {"one", "two", "three"}
   }
 }

--- a/spec/i18n_interpolate_spec.lua
+++ b/spec/i18n_interpolate_spec.lua
@@ -4,7 +4,7 @@ local interpolate = require 'i18n.interpolate'
 
 describe('i18n.interpolate', function()
   it("exists", function()
-    assert.equal('function', type(interpolate))
+    assert.equal('table', type(interpolate))
   end)
 
   it("performs standard interpolation via string.format", function()

--- a/spec/i18n_spec.lua
+++ b/spec/i18n_spec.lua
@@ -153,6 +153,72 @@ describe('i18n', function()
     end)
   end)
 
+  describe('arrays', function()
+    it("Load supports arrays of strings", function()
+      i18n.set('en.array', {"one", "two", "three"})
+      assert.same({"one", "two", "three"},i18n('array'))
+    end)
+
+    it("Arrays respect languages", function()
+      i18n.set('en.array', {"one", "two", "three"})
+      i18n.set('fr.array', {"un", "deux", "trois"})
+      i18n.setLocale('fr')
+      assert.same({"un", "deux", "trois"},i18n('array'))
+    end)
+
+    it("Variables in array elements can be interpolated", function()
+      i18n.set('en.suede', {"%{count} for the count", "%{show} for the show", "%{ready} to make ready", "go!"})
+      assert.same({
+        "one for the count",
+        "two for the show",
+        "three to make ready",
+        "go!"
+      },i18n('suede',{count = "one", show = "two", ready = "three"}))
+    end)
+
+    it("Variables in array elements can be pluralized", function()
+      i18n.set('en.safe', {"Welcome to Apature!", {
+        one = "%{count} unfortunate retirement today!",
+        other = "%{count} unfortunate retirements today!"}
+      })
+      assert.same({
+        "Welcome to Apature!",
+        "1 unfortunate retirement today!",
+      },i18n('safe',{count = 1}))
+    end)
+
+    it("Variables in array elements can be pluralized independently", function()
+      i18n.set('en.safe', {
+        "Welcome to Apature!", {
+          one = "%{count} unfortunate retirement today!",
+          other = "%{count} unfortunate retirements today!"
+        }, {
+          one = "only %{test} test subject active!",
+          other = "%{test} test subjects active"
+        }
+      })
+      assert.same({
+        "Welcome to Apature!",
+        "10 unfortunate retirements today!",
+        "only 1 test subject active!"
+      },i18n('safe',{count = 10, test = 1}))
+    end)
+
+    it("Without field or value names in string. Pluralisation assumes count as default key", function()
+      i18n.set('en.safe', {
+        "Welcome to Apature!", {
+          one = "It's great!",
+          other = "It's mostly safe!"
+        }
+      })
+      assert.same({
+        "Welcome to Apature!",
+        "It's mostly safe!",
+     },i18n('safe',{count = 2}))
+    end)
+
+  end)
+
   describe('set/getFallbackLocale', function()
     it("defaults to en", function()
       assert.equal('en', i18n.getFallbackLocale())

--- a/spec/i18n_spec.lua
+++ b/spec/i18n_spec.lua
@@ -150,6 +150,7 @@ describe('i18n', function()
       assert.equal('Hello!', i18n('hello'))
       local balance = i18n('balance', {value = 0})
       assert.equal('Your account balance is 0.', balance)
+      assert.same({"one", "two", "three"}, i18n('array'))
     end)
   end)
 

--- a/spec/i18n_spec.lua
+++ b/spec/i18n_spec.lua
@@ -177,6 +177,23 @@ describe('i18n', function()
       },i18n('suede',{count = "one", show = "two", ready = "three"}))
     end)
 
+    it("Interpolation produces different results when called with different values", function()
+      i18n.set('en.suede', {"%{count} for the count", "%{show} for the show", "%{ready} to make ready", "go!"})
+      assert.same({
+        "one for the count",
+        "two for the show",
+        "three to make ready",
+        "go!"
+      },i18n('suede',{count = "one", show = "two", ready = "three"}))
+
+      assert.same({
+        "a for the count",
+        "b for the show",
+        "c to make ready",
+        "go!"
+      },i18n('suede',{count = "a", show = "b", ready = "c"}))
+    end)
+
     it("Variables in array elements can be pluralized", function()
       i18n.set('en.safe', {"Welcome to Apature!", {
         one = "%{count} unfortunate retirement today!",
@@ -217,7 +234,6 @@ describe('i18n', function()
         "It's mostly safe!",
      },i18n('safe',{count = 2}))
     end)
-
   end)
 
   describe('set/getFallbackLocale', function()


### PR DESCRIPTION
- Add array type detection and validation
- Support arrays in translation tables
- Allow interpolation within array elements
- Enable pluralization within array elements
- Add extensive test coverage for array features

Cherry-picked from kikito/i18n.lua#30